### PR TITLE
feat: ship starter policy templates for code-agent usage (#9)

### DIFF
--- a/policies/code-agent-safe.yaml
+++ b/policies/code-agent-safe.yaml
@@ -1,0 +1,41 @@
+version: "1.0"
+name: "code-agent-safe"
+
+# Conservative guardrails for AI coding agents.
+# Blocks destructive operations and protects sensitive files.
+# Suitable for most development workflows.
+
+static_rules:
+  forbidden_tools:
+    - delete_database
+    - drop_table
+    - purge_all
+    - truncate_table
+    - format_disk
+    - rm_rf
+
+  protected_paths:
+    - .env
+    - .env.*
+    - "*.pem"
+    - "*.key"
+    - "*.cert"
+    - .ssh/*
+    - .aws/*
+    - .git/config
+    - secrets/*
+    - credentials/*
+    - /etc/*
+
+  max_tokens_per_call: 8000
+
+# Semantic rules are optional. Uncomment to enable LLM-based intent analysis.
+# semantic_rules:
+#   provider: ollama
+#   mode: advisory
+#   guardrail_model: llama-guard-3-8b
+#   critical_intent_threshold: 0.85
+#   constraints:
+#     - intent: modify_source_code
+#       allowed_scope: Application code changes only
+#       forbidden_scope: Infrastructure, CI/CD, or deployment configs

--- a/policies/minimal.yaml
+++ b/policies/minimal.yaml
@@ -1,0 +1,15 @@
+version: "1.0"
+name: "minimal"
+
+# Minimal policy to get started with IntentGuard.
+# Blocks only the most dangerous operations.
+# Customize by adding more rules from the other templates.
+
+static_rules:
+  forbidden_tools:
+    - delete_database
+    - purge_all
+  protected_paths:
+    - .env
+    - "*.key"
+    - "*.pem"

--- a/policies/repo-write-guard.yaml
+++ b/policies/repo-write-guard.yaml
@@ -1,0 +1,49 @@
+version: "1.0"
+name: "repo-write-guard"
+
+# Strict guardrails for repository write protection.
+# Prevents modification of CI/CD, infrastructure, and security-critical files.
+# Use when agents should only modify application code, not config/infra.
+
+static_rules:
+  forbidden_tools:
+    - delete_database
+    - drop_table
+    - purge_all
+    - exec_sql
+    - run_migration
+
+  protected_paths:
+    - .env
+    - .env.*
+    - .github/*
+    - .gitlab-ci.yml
+    - Dockerfile
+    - docker-compose*.yml
+    - "*.tf"
+    - "*.tfvars"
+    - Makefile
+    - package-lock.json
+    - yarn.lock
+    - poetry.lock
+    - Gemfile.lock
+    - go.sum
+    - requirements.txt
+    - setup.py
+    - pyproject.toml
+    - .gitignore
+    - LICENSE
+    - "*.pem"
+    - "*.key"
+
+  max_tokens_per_call: 4000
+
+custom_policies:
+  - tool_name: write_file
+    args:
+      all_present:
+        - path
+        - content
+      should_not_present:
+        - force
+        - overwrite_protected

--- a/tests/test_starter_templates.py
+++ b/tests/test_starter_templates.py
@@ -1,0 +1,73 @@
+"""Validation tests for starter policy templates in policies/."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from intent_guard.sdk.engine import IntentGuardEngine
+
+POLICIES_DIR = Path(__file__).resolve().parent.parent / "policies"
+TEMPLATE_FILES = sorted(POLICIES_DIR.glob("*.yaml"))
+
+
+@pytest.fixture(params=[p.name for p in TEMPLATE_FILES], ids=[p.stem for p in TEMPLATE_FILES])
+def template_path(request: pytest.FixtureRequest) -> Path:
+    return POLICIES_DIR / request.param
+
+
+# ── Loading & structure ──────────────────────────────────────────────
+
+
+def test_yaml_loads_without_error(template_path: Path) -> None:
+    data = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+
+
+def test_has_required_fields(template_path: Path) -> None:
+    data = yaml.safe_load(template_path.read_text(encoding="utf-8"))
+    assert "version" in data, "missing 'version'"
+    assert "name" in data, "missing 'name'"
+
+
+def test_engine_loads_from_template(template_path: Path) -> None:
+    engine = IntentGuardEngine.from_policy_file(template_path)
+    assert engine is not None
+
+
+def test_engine_evaluates_safe_call(template_path: Path) -> None:
+    engine = IntentGuardEngine.from_policy_file(template_path)
+    decision = engine.evaluate_tool_call("read_file", {"path": "src/main.py"})
+    assert decision.allowed is True
+
+
+# ── Behavioural checks (at least one template must satisfy each) ─────
+
+
+def _load_all_engines() -> list[tuple[str, IntentGuardEngine]]:
+    return [
+        (p.stem, IntentGuardEngine.from_policy_file(p))
+        for p in TEMPLATE_FILES
+    ]
+
+
+def test_at_least_one_blocks_forbidden_tool() -> None:
+    blocked = False
+    for name, engine in _load_all_engines():
+        decision = engine.evaluate_tool_call("delete_database", {})
+        if not decision.allowed:
+            blocked = True
+            break
+    assert blocked, "No template blocked the forbidden tool 'delete_database'"
+
+
+def test_at_least_one_blocks_protected_path() -> None:
+    blocked = False
+    for name, engine in _load_all_engines():
+        decision = engine.evaluate_tool_call("write_file", {"path": ".env"})
+        if not decision.allowed:
+            blocked = True
+            break
+    assert blocked, "No template blocked a write to the protected path '.env'"


### PR DESCRIPTION
Fixes #9

- Three starter templates: code-agent-safe, repo-write-guard, minimal
- Pick one and customize in 3 lines
- Validation tests for all templates