### PR TITLE
feat: add secret/PII scanning in tool call arguments (#28)

### DIFF
--- a/intent_guard/sdk/engine.py
+++ b/intent_guard/sdk/engine.py
@@ -152,6 +152,22 @@ class IntentGuardEngine:
                             rule_id="static.injection_patterns",
                         )
 
+        sensitive_patterns = static_rules.get("sensitive_data_patterns", [])
+        if sensitive_patterns:
+            for string_val in self._extract_all_strings(arguments):
+                for pat_config in sensitive_patterns:
+                    pat_name = pat_config.get("name", "unknown")
+                    pat_regex = pat_config.get("pattern", "")
+                    if pat_regex and re.search(pat_regex, string_val):
+                        return self._decision(
+                            allowed=False,
+                            reason=f"sensitive data detected: {pat_name}",
+                            requires_approval=True,
+                            code="BLOCK_SENSITIVE_DATA",
+                            severity="high",
+                            rule_id="static.sensitive_data_patterns",
+                        )
+
         return self._decision(
             allowed=True,
             reason="static checks passed",
@@ -317,6 +333,16 @@ class IntentGuardEngine:
             if isinstance(value, int):
                 return value
         return None
+
+    def _extract_all_strings(self, value: Any) -> Iterable[str]:
+        if isinstance(value, dict):
+            for nested in value.values():
+                yield from self._extract_all_strings(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                yield from self._extract_all_strings(nested)
+        elif isinstance(value, str):
+            yield value
 
     def _extract_path_candidates(self, value: Any, parent_key: str = "") -> Iterable[str]:
         if isinstance(value, dict):

--- a/schema/policy.yaml
+++ b/schema/policy.yaml
@@ -21,6 +21,15 @@ static_rules:
     - "pretend you are"
     - "override.*policy"
     - "bypass.*security"
+  sensitive_data_patterns:
+    - name: "AWS Access Key"
+      pattern: "AKIA[0-9A-Z]{16}"
+    - name: "GitHub Token"
+      pattern: "gh[ps]_[A-Za-z0-9_]{36,}"
+    - name: "Email Address"
+      pattern: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
+    - name: "SSN"
+      pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
 
 semantic_rules:
   provider: ollama

--- a/tests/test_secret_pii_scanning.py
+++ b/tests/test_secret_pii_scanning.py
@@ -1,0 +1,119 @@
+"""Tests for sensitive data / PII scanning in tool call arguments."""
+
+from __future__ import annotations
+
+import pytest
+
+from intent_guard.sdk.engine import IntentGuardEngine
+
+SENSITIVE_PATTERNS = [
+    {"name": "AWS Access Key", "pattern": "AKIA[0-9A-Z]{16}"},
+    {"name": "GitHub Token", "pattern": "gh[ps]_[A-Za-z0-9_]{36,}"},
+    {
+        "name": "Generic API Key",
+        "pattern": "(?i)(api[_-]?key|apikey|api_secret)\\s*[=:]\\s*\\S+",
+    },
+    {
+        "name": "Generic Secret",
+        "pattern": "(?i)(password|passwd|secret|token)\\s*[=:]\\s*\\S+",
+    },
+    {
+        "name": "Email Address",
+        "pattern": "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+    },
+    {"name": "SSN", "pattern": "\\b\\d{3}-\\d{2}-\\d{4}\\b"},
+]
+
+
+def _engine(patterns=None):
+    policy = {"static_rules": {}}
+    if patterns is not None:
+        policy["static_rules"]["sensitive_data_patterns"] = patterns
+    return IntentGuardEngine(policy=policy)
+
+
+class TestSensitiveDataScanning:
+    def test_aws_key_blocked(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "aws_key = AKIAIOSFODNN7EXAMPLE"},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "AWS Access Key" in decision.reason
+
+    def test_github_token_blocked(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        token = "ghp_" + "A" * 36
+        decision = engine.evaluate_tool_call(
+            "run_command",
+            {"command": "curl -H 'Authorization: token " + token + "'"},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "GitHub Token" in decision.reason
+
+    def test_email_blocked(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "send_message",
+            {"body": "Contact me at user@example.com"},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "Email Address" in decision.reason
+
+    def test_ssn_blocked(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "SSN: 123-45-6789"},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "SSN" in decision.reason
+
+    def test_generic_api_key_blocked(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "api_key = sk-live-abc123"},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "Generic API Key" in decision.reason
+
+    def test_clean_arguments_pass(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "Hello, world!", "path": "greeting.txt"},
+        )
+        assert decision.allowed
+
+    def test_nested_values_scanned(self):
+        engine = _engine(SENSITIVE_PATTERNS)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"metadata": {"inner": {"deep": "key=AKIAIOSFODNN7EXAMPLE"}}},
+        )
+        assert not decision.allowed
+        assert decision.code == "BLOCK_SENSITIVE_DATA"
+        assert "AWS Access Key" in decision.reason
+
+    def test_no_patterns_configured_backward_compatible(self):
+        engine = _engine(patterns=None)
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "AKIAIOSFODNN7EXAMPLE"},
+        )
+        assert decision.allowed
+
+    def test_empty_patterns_list_no_checking(self):
+        engine = _engine(patterns=[])
+        decision = engine.evaluate_tool_call(
+            "write_file",
+            {"content": "AKIAIOSFODNN7EXAMPLE"},
+        )
+        assert decision.allowed


### PR DESCRIPTION
## Summary
Adds secret and PII detection to static rule checks. Tool call arguments are recursively scanned for sensitive data patterns (AWS keys, GitHub tokens, emails, SSNs).

## Changes
- **engine.py**: Added `sensitive_data_patterns` check in `_run_static_checks()` — blocks tool calls containing secrets/PII
- **policy.yaml**: Added example patterns for AWS keys, GitHub tokens, emails, SSNs
- **test_secret_pii_scanning.py**: 9 tests covering all pattern types, nested scanning, clean pass-through, and backward compatibility

## Testing
All 87 tests pass (78 existing + 9 new).

Closes #28

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>