### PR TITLE
feat: add semantic decision cache (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,20 @@ Define tiers by assigning tools in `provider_fail_mode.by_tool`.
 
 `semantic_rules.prompt_version` is copied into every semantic decision and log entry as `semantic_prompt_version` so prompt changes are auditable.
 
+### Semantic decision caching
+
+To reduce repeated provider calls for identical semantic evaluations:
+
+```yaml
+semantic_rules:
+  decision_cache:
+    enabled: true
+    max_size: 256
+    ttl_seconds: 300
+```
+
+Cache key uses `(tool_name, arguments, task_context)`. Static checks always run; only semantic verdicts are cached.
+
 ### LiteLLM provider
 
 To use the API provider, set in `.env` (or process env):

--- a/intent_guard/sdk/decision_cache.py
+++ b/intent_guard/sdk/decision_cache.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+from intent_guard.sdk.providers import SemanticVerdict
+
+
+@dataclass
+class CacheEntry:
+    verdict: SemanticVerdict
+    expires_at: float
+
+
+class SemanticDecisionCache:
+    def __init__(self, max_size: int = 256, ttl_seconds: int = 300):
+        self.max_size = max(1, int(max_size))
+        self.ttl_seconds = max(1, int(ttl_seconds))
+        self._items: OrderedDict[str, CacheEntry] = OrderedDict()
+
+    def make_key(self, tool_name: str, arguments: dict[str, Any], task_context: str | None) -> str:
+        payload = {
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "task_context": task_context or "",
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def get(self, key: str, now: float | None = None) -> SemanticVerdict | None:
+        current_time = time.time() if now is None else now
+        entry = self._items.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at <= current_time:
+            self._items.pop(key, None)
+            return None
+        self._items.move_to_end(key)
+        return entry.verdict
+
+    def set(self, key: str, verdict: SemanticVerdict, now: float | None = None) -> None:
+        current_time = time.time() if now is None else now
+        self._items[key] = CacheEntry(verdict=verdict, expires_at=current_time + self.ttl_seconds)
+        self._items.move_to_end(key)
+        while len(self._items) > self.max_size:
+            self._items.popitem(last=False)

--- a/intent_guard/sdk/engine.py
+++ b/intent_guard/sdk/engine.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import yaml
 
+from intent_guard.sdk.decision_cache import SemanticDecisionCache
 from intent_guard.sdk.providers import GuardrailProvider, SemanticProviderUnavailable
 
 
@@ -39,10 +40,22 @@ class IntentGuardEngine:
     def __init__(self, policy: dict[str, Any], provider: GuardrailProvider | None = None):
         self.policy = policy or {}
         self.provider = provider
+        self.semantic_cache = self._build_semantic_cache()
 
     def reload_policy(self, policy: dict[str, Any]) -> None:
         """Hot-swap the policy dict. In-flight evaluations may use old policy."""
         self.policy = policy
+        self.semantic_cache = self._build_semantic_cache()
+
+    def _build_semantic_cache(self) -> SemanticDecisionCache:
+        semantic_rules = self.policy.get("semantic_rules", {})
+        cache_config = semantic_rules.get("decision_cache", {})
+        enabled = bool(cache_config.get("enabled", False))
+        if not enabled:
+            return SemanticDecisionCache(max_size=1, ttl_seconds=1)
+        max_size = int(cache_config.get("max_size", 256))
+        ttl_seconds = int(cache_config.get("ttl_seconds", 300))
+        return SemanticDecisionCache(max_size=max_size, ttl_seconds=ttl_seconds)
 
     @classmethod
     def from_policy_file(cls, policy_path: str | Path, provider: GuardrailProvider | None = None) -> "IntentGuardEngine":
@@ -248,14 +261,32 @@ class IntentGuardEngine:
             prompt_version,
             semantic_example_name,
         )
-        try:
-            verdict = self.provider.judge(prompt)
-        except SemanticProviderUnavailable as exc:
-            return self._semantic_provider_failure_decision(
-                tool_name=tool_name,
-                semantic_rules=semantic_rules,
-                reason=str(exc) or "semantic provider failed",
-            )
+        cache_config = semantic_rules.get("decision_cache", {})
+        cache_enabled = bool(cache_config.get("enabled", False))
+        cache_key = self.semantic_cache.make_key(tool_name, arguments, task_context)
+        if cache_enabled:
+            cached = self.semantic_cache.get(cache_key)
+            if cached is not None:
+                verdict = cached
+            else:
+                try:
+                    verdict = self.provider.judge(prompt)
+                except SemanticProviderUnavailable as exc:
+                    return self._semantic_provider_failure_decision(
+                        tool_name=tool_name,
+                        semantic_rules=semantic_rules,
+                        reason=str(exc) or "semantic provider failed",
+                    )
+                self.semantic_cache.set(cache_key, verdict)
+        else:
+            try:
+                verdict = self.provider.judge(prompt)
+            except SemanticProviderUnavailable as exc:
+                return self._semantic_provider_failure_decision(
+                    tool_name=tool_name,
+                    semantic_rules=semantic_rules,
+                    reason=str(exc) or "semantic provider failed",
+                )
 
         if verdict.safe and verdict.score >= threshold:
             return self._decision(

--- a/intent_guard/sdk/validator.py
+++ b/intent_guard/sdk/validator.py
@@ -151,6 +151,22 @@ def _validate_semantic_rules(rules: Any) -> list[str]:
                 if not isinstance(item, dict):
                     errors.append(f"\'semantic_rules.constraints[{i}]\' must be a dict")
 
+    if "decision_cache" in rules:
+        dc = rules["decision_cache"]
+        if not isinstance(dc, dict):
+            errors.append("'semantic_rules.decision_cache' must be a dict")
+        else:
+            if "enabled" in dc and not isinstance(dc["enabled"], bool):
+                errors.append("'semantic_rules.decision_cache.enabled' must be boolean")
+            if "max_size" in dc:
+                max_size = dc["max_size"]
+                if not isinstance(max_size, int) or isinstance(max_size, bool) or max_size <= 0:
+                    errors.append("'semantic_rules.decision_cache.max_size' must be a positive integer")
+            if "ttl_seconds" in dc:
+                ttl = dc["ttl_seconds"]
+                if not isinstance(ttl, int) or isinstance(ttl, bool) or ttl <= 0:
+                    errors.append("'semantic_rules.decision_cache.ttl_seconds' must be a positive integer")
+
     return errors
 
 

--- a/schema/policy.yaml
+++ b/schema/policy.yaml
@@ -49,6 +49,10 @@ semantic_rules:
     by_tool:
       delete_database: enforce
       purge_all: enforce
+  decision_cache:
+    enabled: true
+    max_size: 256
+    ttl_seconds: 300
   constraints:
     - intent: modify_source_code
       allowed_scope: Actions must only affect UI components or styles.

--- a/tests/test_decision_cache.py
+++ b/tests/test_decision_cache.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from intent_guard.sdk.decision_cache import SemanticDecisionCache
+from intent_guard.sdk.engine import IntentGuardEngine
+from intent_guard.sdk.providers import SemanticVerdict
+
+
+@dataclass
+class CountingProvider:
+    verdict: SemanticVerdict
+    calls: int = 0
+
+    def judge(self, _prompt: str) -> SemanticVerdict:
+        self.calls += 1
+        return self.verdict
+
+
+def test_semantic_cache_hit_avoids_second_provider_call():
+    provider = CountingProvider(verdict=SemanticVerdict(safe=True, score=0.95, raw='{"safe":true,"score":0.95}'))
+    engine = IntentGuardEngine(
+        policy={
+            "semantic_rules": {
+                "mode": "enforce",
+                "critical_intent_threshold": 0.85,
+                "decision_cache": {"enabled": True, "max_size": 16, "ttl_seconds": 300},
+                "constraints": [],
+            }
+        },
+        provider=provider,
+    )
+
+    first = engine.evaluate_tool_call("read_file", {"path": "README.md"}, "docs")
+    second = engine.evaluate_tool_call("read_file", {"path": "README.md"}, "docs")
+    assert first.allowed is True
+    assert second.allowed is True
+    assert provider.calls == 1
+
+
+def test_semantic_cache_miss_for_different_arguments():
+    provider = CountingProvider(verdict=SemanticVerdict(safe=True, score=0.95, raw='{"safe":true,"score":0.95}'))
+    engine = IntentGuardEngine(
+        policy={
+            "semantic_rules": {
+                "mode": "enforce",
+                "critical_intent_threshold": 0.85,
+                "decision_cache": {"enabled": True, "max_size": 16, "ttl_seconds": 300},
+                "constraints": [],
+            }
+        },
+        provider=provider,
+    )
+
+    engine.evaluate_tool_call("read_file", {"path": "README.md"}, "docs")
+    engine.evaluate_tool_call("read_file", {"path": "CHANGELOG.md"}, "docs")
+    assert provider.calls == 2
+
+
+def test_semantic_cache_ttl_expiry():
+    cache = SemanticDecisionCache(max_size=4, ttl_seconds=10)
+    key = cache.make_key("tool", {"a": 1}, "ctx")
+    verdict = SemanticVerdict(safe=True, score=1.0, raw='{"safe":true,"score":1.0}')
+    cache.set(key, verdict, now=100)
+    assert cache.get(key, now=105) is not None
+    assert cache.get(key, now=111) is None
+
+
+def test_semantic_cache_lru_eviction():
+    cache = SemanticDecisionCache(max_size=2, ttl_seconds=300)
+    v = SemanticVerdict(safe=True, score=1.0, raw='{"safe":true,"score":1.0}')
+    k1 = cache.make_key("a", {"x": 1}, "ctx")
+    k2 = cache.make_key("b", {"x": 2}, "ctx")
+    k3 = cache.make_key("c", {"x": 3}, "ctx")
+    cache.set(k1, v, now=1)
+    cache.set(k2, v, now=2)
+    _ = cache.get(k1, now=3)  # refresh k1
+    cache.set(k3, v, now=4)  # evicts k2
+    assert cache.get(k1, now=5) is not None
+    assert cache.get(k2, now=5) is None
+    assert cache.get(k3, now=5) is not None

--- a/tests/test_policy_validation.py
+++ b/tests/test_policy_validation.py
@@ -140,3 +140,15 @@ def test_invalid_decode_arguments_type():
     policy = {"static_rules": {"decode_arguments": "yes"}}
     errors = validate_policy(policy)
     assert any("decode_arguments" in e for e in errors)
+
+
+def test_invalid_decision_cache_settings():
+    policy = {
+        "semantic_rules": {
+            "decision_cache": {"enabled": "yes", "max_size": 0, "ttl_seconds": -1},
+        }
+    }
+    errors = validate_policy(policy)
+    assert any("decision_cache.enabled" in e for e in errors)
+    assert any("decision_cache.max_size" in e for e in errors)
+    assert any("decision_cache.ttl_seconds" in e for e in errors)


### PR DESCRIPTION
Summary: Adds LRU+TTL semantic decision caching for repeated tool calls.

What changed:
- Added SemanticDecisionCache keyed by tool_name + arguments + task_context
- Added decision_cache settings under semantic_rules with enabled/max_size/ttl_seconds
- Integrated cache into semantic evaluation path (static checks still always run)
- Added tests for cache hit/miss, TTL expiry, and LRU eviction

Validation:
- Focused tests: 21 passed
- Full suite: 123 passed

Closes #34