### PR TITLE
Add per-tool sliding-window rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ static_rules:
   forbidden_tools: ["delete_database", "purge_all"]
   protected_paths: ["/etc/*", ".env", "src/auth/*"]
   max_tokens_per_call: 4000
+  rate_limits:
+    enabled: 1 # required to turn rate limiting on; 0/false bypasses checks
+    default:
+      max_calls: 60
+      window_seconds: 60
+    by_tool:
+      write_file:
+        max_calls: 10
+        window_seconds: 60
 
 custom_policies:
   - tool_name: write_file

--- a/feature-example.md
+++ b/feature-example.md
@@ -53,7 +53,27 @@ custom_policies:
 
 ---
 
-## 5) Prompt injection detection
+## 5) Per-tool sliding-window rate limiting (opt-in)
+
+```yaml
+static_rules:
+  rate_limits:
+    enabled: 1 # required to turn on rate limiting; 0/false bypasses checks
+    default:
+      max_calls: 60
+      window_seconds: 60
+    by_tool:
+      write_file:
+        max_calls: 10
+        window_seconds: 60
+      delete_file:
+        max_calls: 5
+        window_seconds: 60
+```
+
+---
+
+## 6) Prompt injection detection
 
 ```yaml
 static_rules:
@@ -66,7 +86,7 @@ static_rules:
 
 ---
 
-## 6) Secret/PII detection in arguments
+## 7) Secret/PII detection in arguments
 
 ```yaml
 static_rules:
@@ -83,7 +103,7 @@ static_rules:
 
 ---
 
-## 7) Encoded bypass defense (URL/Base64/Unicode normalization)
+## 8) Encoded bypass defense (URL/Base64/Unicode normalization)
 
 ```yaml
 static_rules:
@@ -92,7 +112,7 @@ static_rules:
 
 ---
 
-## 8) Semantic intent evaluation (task-aware guardrails)
+## 9) Semantic intent evaluation (task-aware guardrails)
 
 ```yaml
 semantic_rules:
@@ -106,7 +126,7 @@ semantic_rules:
 
 ---
 
-## 9) Structured semantic verdicts + prompt versioning
+## 10) Structured semantic verdicts + prompt versioning
 
 ```yaml
 semantic_rules:
@@ -117,7 +137,7 @@ Note: structured verdict parsing is built into the semantic provider path; this 
 
 ---
 
-## 10) Provider resilience (retry/jitter/circuit breaker)
+## 11) Provider resilience (retry/jitter/circuit breaker)
 
 ```yaml
 semantic_rules:
@@ -133,7 +153,7 @@ semantic_rules:
 
 ---
 
-## 11) Per-tool semantic fail mode (safe fallback behavior)
+## 12) Per-tool semantic fail mode (safe fallback behavior)
 
 ```yaml
 semantic_rules:
@@ -146,7 +166,7 @@ semantic_rules:
 
 ---
 
-## 12) Semantic decision caching (LRU + TTL)
+## 13) Semantic decision caching (LRU + TTL)
 
 ```yaml
 semantic_rules:
@@ -158,7 +178,7 @@ semantic_rules:
 
 ---
 
-## 13) Response-side inspection (outbound filtering)
+## 14) Response-side inspection (outbound filtering)
 
 ```yaml
 response_rules:
@@ -173,7 +193,7 @@ response_rules:
 
 ---
 
-## 14) Tool metadata rug-pull detection
+## 15) Tool metadata rug-pull detection
 
 ```yaml
 tool_change_rules:
@@ -183,7 +203,7 @@ tool_change_rules:
 
 ---
 
-## 15) Advisory rollout mode (log, don't block)
+## 16) Advisory rollout mode (log, don't block)
 
 Policy:
 
@@ -200,7 +220,7 @@ intent-guard-proxy --advisory --policy schema/policy.yaml --target "<mcp command
 
 ---
 
-## 16) Interactive approvals
+## 17) Interactive approvals
 
 Runtime:
 
@@ -210,7 +230,7 @@ intent-guard-proxy --ask-approval --policy schema/policy.yaml --target "<mcp com
 
 ---
 
-## 17) Webhook approval backend
+## 18) Webhook approval backend
 
 Runtime:
 
@@ -225,7 +245,7 @@ intent-guard-proxy \
 
 ---
 
-## 18) Break-glass controls (runtime env)
+## 19) Break-glass controls (runtime env)
 
 ```bash
 # Basic break-glass
@@ -238,7 +258,7 @@ export INTENT_GUARD_BREAK_GLASS_SIGNING_KEY="<secret>"
 
 ---
 
-## 19) Hot-reload policy without restart
+## 20) Hot-reload policy without restart
 
 Runtime:
 
@@ -248,7 +268,7 @@ intent-guard-proxy --watch-policy --policy schema/policy.yaml --target "<mcp com
 
 ---
 
-## 20) Policy schema validation
+## 21) Policy schema validation
 
 Runtime:
 
@@ -258,7 +278,7 @@ intent-guard-proxy --validate --policy schema/policy.yaml
 
 ---
 
-## 21) Starter secure policy templates
+## 22) Starter secure policy templates
 
 Use one of:
 
@@ -270,7 +290,7 @@ policies/repo-write-guard.yaml
 
 ---
 
-## 22) Native hook integration (Claude / Copilot / Cursor)
+## 23) Native hook integration (Claude / Copilot / Cursor)
 
 Command:
 
@@ -288,7 +308,7 @@ hooks/cursor/hooks.json
 
 ---
 
-## 23) Audit-friendly decision metadata (output contract)
+## 24) Audit-friendly decision metadata (output contract)
 
 No extra policy needed; emitted in decisions/logs automatically:
 

--- a/features.md
+++ b/features.md
@@ -8,6 +8,7 @@ It focuses on **preventing dangerous actions before execution**, **detecting dat
 - **Forbidden tool blocking** (`forbidden_tools`)
 - **Protected path enforcement** (`protected_paths`) with traversal-safe normalization
 - **Token budget limits** (`max_tokens_per_call`)
+- **Per-tool sliding-window rate limiting** (`rate_limits`) with opt-in enable/bypass (`enabled: 1` or `0/false`)
 - **Custom per-tool argument policies** (`custom_policies`)
 - **Prompt injection detection** in tool-call arguments
 - **Secret/PII detection** in arguments (keys, tokens, emails, SSN patterns)

--- a/intent_guard/sdk/engine.py
+++ b/intent_guard/sdk/engine.py
@@ -17,6 +17,7 @@ import yaml
 
 from intent_guard.sdk.decision_cache import SemanticDecisionCache
 from intent_guard.sdk.providers import GuardrailProvider, SemanticProviderUnavailable
+from intent_guard.sdk.rate_limiter import ToolRateLimiter
 
 
 @dataclass
@@ -41,11 +42,13 @@ class IntentGuardEngine:
         self.policy = policy or {}
         self.provider = provider
         self.semantic_cache = self._build_semantic_cache()
+        self.rate_limiter = self._build_rate_limiter()
 
     def reload_policy(self, policy: dict[str, Any]) -> None:
         """Hot-swap the policy dict. In-flight evaluations may use old policy."""
         self.policy = policy
         self.semantic_cache = self._build_semantic_cache()
+        self.rate_limiter = self._build_rate_limiter()
 
     def _build_semantic_cache(self) -> SemanticDecisionCache:
         semantic_rules = self.policy.get("semantic_rules", {})
@@ -56,6 +59,13 @@ class IntentGuardEngine:
         max_size = int(cache_config.get("max_size", 256))
         ttl_seconds = int(cache_config.get("ttl_seconds", 300))
         return SemanticDecisionCache(max_size=max_size, ttl_seconds=ttl_seconds)
+
+    def _build_rate_limiter(self) -> ToolRateLimiter:
+        static_rules = self.policy.get("static_rules", {})
+        rate_limits_config = static_rules.get("rate_limits")
+        if not rate_limits_config or not isinstance(rate_limits_config, dict):
+            return ToolRateLimiter()
+        return ToolRateLimiter.from_config(rate_limits_config)
 
     @classmethod
     def from_policy_file(cls, policy_path: str | Path, provider: GuardrailProvider | None = None) -> "IntentGuardEngine":
@@ -119,6 +129,17 @@ class IntentGuardEngine:
                 code="BLOCK_TOKEN_LIMIT",
                 severity="medium",
                 rule_id="static.max_tokens_per_call",
+            )
+
+        allowed, rate_reason = self.rate_limiter.check(tool_name)
+        if not allowed:
+            return self._decision(
+                allowed=False,
+                reason=rate_reason,
+                requires_approval=False,
+                code="BLOCK_RATE_LIMIT",
+                severity="medium",
+                rule_id="static.rate_limits",
             )
 
         protected_paths = static_rules.get("protected_paths", [])

--- a/intent_guard/sdk/rate_limiter.py
+++ b/intent_guard/sdk/rate_limiter.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ToolRateLimit:
+    max_calls: int
+    window_seconds: float
+
+
+class ToolRateLimiter:
+    """Sliding-window rate limiter keyed by tool name.
+
+    Each tool maintains a deque of timestamps.  On ``check()``, expired
+    entries are pruned and the call is allowed only when the remaining
+    count is below the configured maximum for the window.
+    """
+
+    def __init__(
+        self,
+        default: ToolRateLimit | None = None,
+        by_tool: dict[str, ToolRateLimit] | None = None,
+    ):
+        self._default = default
+        self._by_tool: dict[str, ToolRateLimit] = by_tool or {}
+        self._windows: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "ToolRateLimiter":
+        """Build a limiter from the ``rate_limits`` policy section.
+
+        Expected shape::
+
+            rate_limits:
+              default:
+                max_calls: 60
+                window_seconds: 60
+              by_tool:
+                write_file:
+                  max_calls: 10
+                  window_seconds: 60
+        """
+        default_cfg = config.get("default")
+        default = (
+            ToolRateLimit(
+                max_calls=int(default_cfg["max_calls"]),
+                window_seconds=float(default_cfg["window_seconds"]),
+            )
+            if default_cfg
+            else None
+        )
+        by_tool: dict[str, ToolRateLimit] = {}
+        for tool_name, tool_cfg in (config.get("by_tool") or {}).items():
+            by_tool[tool_name] = ToolRateLimit(
+                max_calls=int(tool_cfg["max_calls"]),
+                window_seconds=float(tool_cfg["window_seconds"]),
+            )
+        return cls(default=default, by_tool=by_tool)
+
+    def _limit_for(self, tool_name: str) -> ToolRateLimit | None:
+        return self._by_tool.get(tool_name, self._default)
+
+    def check(self, tool_name: str, now: float | None = None) -> tuple[bool, str]:
+        """Return ``(allowed, reason)``.
+
+        An optional *now* parameter supports deterministic testing.
+        """
+        limit = self._limit_for(tool_name)
+        if limit is None:
+            return True, "no rate limit configured"
+
+        current_time = time.time() if now is None else now
+        cutoff = current_time - limit.window_seconds
+
+        with self._lock:
+            window = self._windows.setdefault(tool_name, deque())
+            # Prune expired entries
+            while window and window[0] <= cutoff:
+                window.popleft()
+
+            if len(window) >= limit.max_calls:
+                return (
+                    False,
+                    f"tool '{tool_name}' exceeded rate limit: "
+                    f"{limit.max_calls} calls per {limit.window_seconds}s window",
+                )
+
+            window.append(current_time)
+            return True, "rate limit ok"
+
+    def reset(self, tool_name: str | None = None) -> None:
+        """Clear recorded timestamps.
+
+        If *tool_name* is ``None``, all windows are cleared.
+        """
+        with self._lock:
+            if tool_name is None:
+                self._windows.clear()
+            else:
+                self._windows.pop(tool_name, None)

--- a/intent_guard/sdk/rate_limiter.py
+++ b/intent_guard/sdk/rate_limiter.py
@@ -23,9 +23,11 @@ class ToolRateLimiter:
 
     def __init__(
         self,
+        enabled: bool = True,
         default: ToolRateLimit | None = None,
         by_tool: dict[str, ToolRateLimit] | None = None,
     ):
+        self._enabled = enabled
         self._default = default
         self._by_tool: dict[str, ToolRateLimit] = by_tool or {}
         self._windows: dict[str, deque[float]] = {}
@@ -38,6 +40,7 @@ class ToolRateLimiter:
         Expected shape::
 
             rate_limits:
+              enabled: 1  # opt-in
               default:
                 max_calls: 60
                 window_seconds: 60
@@ -46,6 +49,16 @@ class ToolRateLimiter:
                   max_calls: 10
                   window_seconds: 60
         """
+        enabled_value = config.get("enabled")
+        if isinstance(enabled_value, bool):
+            enabled = enabled_value
+        elif isinstance(enabled_value, int) and not isinstance(enabled_value, bool):
+            enabled = enabled_value != 0
+        else:
+            enabled = False
+        if not enabled:
+            return cls(enabled=False)
+
         default_cfg = config.get("default")
         default = (
             ToolRateLimit(
@@ -61,7 +74,7 @@ class ToolRateLimiter:
                 max_calls=int(tool_cfg["max_calls"]),
                 window_seconds=float(tool_cfg["window_seconds"]),
             )
-        return cls(default=default, by_tool=by_tool)
+        return cls(enabled=True, default=default, by_tool=by_tool)
 
     def _limit_for(self, tool_name: str) -> ToolRateLimit | None:
         return self._by_tool.get(tool_name, self._default)
@@ -71,6 +84,9 @@ class ToolRateLimiter:
 
         An optional *now* parameter supports deterministic testing.
         """
+        if not self._enabled:
+            return True, "rate limiting disabled"
+
         limit = self._limit_for(tool_name)
         if limit is None:
             return True, "no rate limit configured"

--- a/intent_guard/sdk/validator.py
+++ b/intent_guard/sdk/validator.py
@@ -88,6 +88,64 @@ def _validate_static_rules(rules: Any) -> list[str]:
     if "decode_arguments" in rules and not isinstance(rules["decode_arguments"], bool):
         errors.append("'static_rules.decode_arguments' must be boolean")
 
+    if "rate_limits" in rules:
+        rate_limits = rules["rate_limits"]
+        if not isinstance(rate_limits, dict):
+            errors.append("'static_rules.rate_limits' must be a dict")
+        else:
+            if "enabled" in rate_limits:
+                enabled = rate_limits["enabled"]
+                if not (
+                    isinstance(enabled, bool)
+                    or (isinstance(enabled, int) and not isinstance(enabled, bool) and enabled in {0, 1})
+                ):
+                    errors.append("'static_rules.rate_limits.enabled' must be boolean or 0/1 integer")
+
+            if "default" in rate_limits:
+                errors.extend(_validate_rate_limit_entry(rate_limits["default"], "static_rules.rate_limits.default"))
+
+            if "by_tool" in rate_limits:
+                by_tool = rate_limits["by_tool"]
+                if not isinstance(by_tool, dict):
+                    errors.append("'static_rules.rate_limits.by_tool' must be a dict")
+                else:
+                    for tool_name, tool_rate_limit in by_tool.items():
+                        if not isinstance(tool_name, str):
+                            errors.append("'static_rules.rate_limits.by_tool' keys must be strings")
+                            continue
+                        errors.extend(
+                            _validate_rate_limit_entry(
+                                tool_rate_limit,
+                                f"static_rules.rate_limits.by_tool.{tool_name}",
+                            )
+                        )
+
+    return errors
+
+
+def _validate_rate_limit_entry(rate_limit: Any, key_path: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(rate_limit, dict):
+        return [f"'{key_path}' must be a dict with 'max_calls' and 'window_seconds'"]
+
+    if "max_calls" not in rate_limit:
+        errors.append(f"'{key_path}.max_calls' is required")
+    else:
+        max_calls = rate_limit["max_calls"]
+        if not isinstance(max_calls, int) or isinstance(max_calls, bool) or max_calls <= 0:
+            errors.append(f"'{key_path}.max_calls' must be a positive integer")
+
+    if "window_seconds" not in rate_limit:
+        errors.append(f"'{key_path}.window_seconds' is required")
+    else:
+        window_seconds = rate_limit["window_seconds"]
+        if (
+            not isinstance(window_seconds, (int, float))
+            or isinstance(window_seconds, bool)
+            or window_seconds <= 0
+        ):
+            errors.append(f"'{key_path}.window_seconds' must be a positive number")
+
     return errors
 
 

--- a/schema/policy.yaml
+++ b/schema/policy.yaml
@@ -10,6 +10,17 @@ static_rules:
     - .env
     - src/auth/*
   max_tokens_per_call: 4000
+  rate_limits:
+    default:
+      max_calls: 60
+      window_seconds: 60
+    by_tool:
+      write_file:
+        max_calls: 10
+        window_seconds: 60
+      delete_file:
+        max_calls: 5
+        window_seconds: 60
   decode_arguments: true
   injection_patterns:
     - "ignore previous instructions"

--- a/schema/policy.yaml
+++ b/schema/policy.yaml
@@ -11,6 +11,7 @@ static_rules:
     - src/auth/*
   max_tokens_per_call: 4000
   rate_limits:
+    enabled: 1
     default:
       max_calls: 60
       window_seconds: 60

--- a/tests/test_policy_validation.py
+++ b/tests/test_policy_validation.py
@@ -152,3 +152,42 @@ def test_invalid_decision_cache_settings():
     assert any("decision_cache.enabled" in e for e in errors)
     assert any("decision_cache.max_size" in e for e in errors)
     assert any("decision_cache.ttl_seconds" in e for e in errors)
+
+
+def test_valid_rate_limits_enabled_zero():
+    policy = {
+        "static_rules": {
+            "rate_limits": {
+                "enabled": 0,
+                "default": {"max_calls": 10, "window_seconds": 60},
+            }
+        }
+    }
+    errors = validate_policy(policy)
+    assert errors == []
+
+
+def test_valid_rate_limits_enabled_boolean():
+    policy = {
+        "static_rules": {
+            "rate_limits": {
+                "enabled": False,
+                "default": {"max_calls": 10, "window_seconds": 60},
+            }
+        }
+    }
+    errors = validate_policy(policy)
+    assert errors == []
+
+
+def test_invalid_rate_limits_enabled_value():
+    policy = {
+        "static_rules": {
+            "rate_limits": {
+                "enabled": 2,
+                "default": {"max_calls": 10, "window_seconds": 60},
+            }
+        }
+    }
+    errors = validate_policy(policy)
+    assert any("static_rules.rate_limits.enabled" in e for e in errors)

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -1,0 +1,233 @@
+"""Tests for per-tool sliding-window rate limiting."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from intent_guard.sdk.rate_limiter import ToolRateLimiter, ToolRateLimit
+from intent_guard.sdk.engine import IntentGuardEngine
+
+
+# ---------------------------------------------------------------------------
+# ToolRateLimiter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRateLimiterDefaults:
+    """Default rate limit enforcement."""
+
+    def test_no_config_always_allows(self):
+        limiter = ToolRateLimiter()
+        allowed, reason = limiter.check("any_tool", now=0.0)
+        assert allowed is True
+        assert "no rate limit" in reason
+
+    def test_default_limit_blocks_after_max(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=3, window_seconds=10))
+        now = 100.0
+        for _ in range(3):
+            allowed, _ = limiter.check("some_tool", now=now)
+            assert allowed is True
+        allowed, reason = limiter.check("some_tool", now=now)
+        assert allowed is False
+        assert "exceeded rate limit" in reason
+
+    def test_default_applies_to_all_tools(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=1, window_seconds=10))
+        now = 100.0
+        allowed, _ = limiter.check("tool_a", now=now)
+        assert allowed is True
+        allowed, _ = limiter.check("tool_a", now=now)
+        assert allowed is False
+        # Different tool still has its own window
+        allowed, _ = limiter.check("tool_b", now=now)
+        assert allowed is True
+
+
+class TestToolRateLimiterPerTool:
+    """Per-tool override rate limits."""
+
+    def test_per_tool_overrides_default(self):
+        limiter = ToolRateLimiter(
+            default=ToolRateLimit(max_calls=100, window_seconds=60),
+            by_tool={"write_file": ToolRateLimit(max_calls=2, window_seconds=60)},
+        )
+        now = 100.0
+        for _ in range(2):
+            allowed, _ = limiter.check("write_file", now=now)
+            assert allowed is True
+        allowed, reason = limiter.check("write_file", now=now)
+        assert allowed is False
+        assert "write_file" in reason
+
+    def test_non_overridden_tool_uses_default(self):
+        limiter = ToolRateLimiter(
+            default=ToolRateLimit(max_calls=2, window_seconds=60),
+            by_tool={"write_file": ToolRateLimit(max_calls=100, window_seconds=60)},
+        )
+        now = 100.0
+        for _ in range(2):
+            allowed, _ = limiter.check("read_file", now=now)
+            assert allowed is True
+        allowed, _ = limiter.check("read_file", now=now)
+        assert allowed is False
+
+
+class TestSlidingWindowExpiry:
+    """Sliding window should expire old calls."""
+
+    def test_calls_allowed_after_window_passes(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=2, window_seconds=10))
+        # Fill up the window at t=100
+        limiter.check("tool", now=100.0)
+        limiter.check("tool", now=100.0)
+        allowed, _ = limiter.check("tool", now=100.0)
+        assert allowed is False
+
+        # At t=111 (window_seconds=10), old entries expired
+        allowed, _ = limiter.check("tool", now=111.0)
+        assert allowed is True
+
+    def test_partial_expiry(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=2, window_seconds=10))
+        limiter.check("tool", now=100.0)
+        limiter.check("tool", now=105.0)
+        # At t=100 + 10 = 110, only the first entry expires; one slot opens
+        allowed, _ = limiter.check("tool", now=111.0)
+        assert allowed is True
+        # Now full again
+        allowed, _ = limiter.check("tool", now=111.0)
+        assert allowed is False
+
+
+class TestReset:
+    """Rate limiter reset."""
+
+    def test_reset_specific_tool(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=1, window_seconds=60))
+        limiter.check("tool_a", now=100.0)
+        limiter.check("tool_b", now=100.0)
+        # Both exhausted
+        allowed_a, _ = limiter.check("tool_a", now=100.0)
+        allowed_b, _ = limiter.check("tool_b", now=100.0)
+        assert allowed_a is False
+        assert allowed_b is False
+
+        limiter.reset("tool_a")
+        allowed_a, _ = limiter.check("tool_a", now=100.0)
+        allowed_b, _ = limiter.check("tool_b", now=100.0)
+        assert allowed_a is True
+        assert allowed_b is False
+
+    def test_reset_all(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=1, window_seconds=60))
+        limiter.check("tool_a", now=100.0)
+        limiter.check("tool_b", now=100.0)
+        limiter.reset()
+        allowed_a, _ = limiter.check("tool_a", now=100.0)
+        allowed_b, _ = limiter.check("tool_b", now=100.0)
+        assert allowed_a is True
+        assert allowed_b is True
+
+
+class TestFromConfig:
+    """Build limiter from policy config dict."""
+
+    def test_from_config(self):
+        config = {
+            "default": {"max_calls": 60, "window_seconds": 60},
+            "by_tool": {
+                "write_file": {"max_calls": 10, "window_seconds": 60},
+            },
+        }
+        limiter = ToolRateLimiter.from_config(config)
+        assert limiter._default is not None
+        assert limiter._default.max_calls == 60
+        assert "write_file" in limiter._by_tool
+        assert limiter._by_tool["write_file"].max_calls == 10
+
+
+class TestThreadSafety:
+    """Basic thread-safety sanity check."""
+
+    def test_concurrent_checks(self):
+        limiter = ToolRateLimiter(default=ToolRateLimit(max_calls=50, window_seconds=60))
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def worker():
+            allowed, _ = limiter.check("tool", now=100.0)
+            with lock:
+                results.append(allowed)
+
+        threads = [threading.Thread(target=worker) for _ in range(100)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        allowed_count = sum(1 for r in results if r)
+        blocked_count = sum(1 for r in results if not r)
+        assert allowed_count == 50
+        assert blocked_count == 50
+
+
+# ---------------------------------------------------------------------------
+# Engine integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestEngineRateLimitIntegration:
+    """Rate limiting wired through IntentGuardEngine."""
+
+    def _make_engine(self, rate_limits: dict) -> IntentGuardEngine:
+        policy = {
+            "name": "test-policy",
+            "version": "1.0",
+            "static_rules": {
+                "rate_limits": rate_limits,
+            },
+        }
+        return IntentGuardEngine(policy=policy)
+
+    def test_engine_blocks_after_limit(self):
+        engine = self._make_engine({
+            "default": {"max_calls": 2, "window_seconds": 60},
+        })
+        d1 = engine.evaluate_tool_call("read_file", {})
+        d2 = engine.evaluate_tool_call("read_file", {})
+        assert d1.allowed is True
+        assert d2.allowed is True
+
+        d3 = engine.evaluate_tool_call("read_file", {})
+        assert d3.allowed is False
+        assert d3.code == "BLOCK_RATE_LIMIT"
+        assert d3.severity == "medium"
+
+    def test_engine_no_rate_limits_configured(self):
+        engine = IntentGuardEngine(policy={"static_rules": {}})
+        decision = engine.evaluate_tool_call("any_tool", {})
+        assert decision.allowed is True
+
+    def test_engine_reload_policy_rebuilds_limiter(self):
+        engine = self._make_engine({
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        engine.evaluate_tool_call("tool", {})
+        d = engine.evaluate_tool_call("tool", {})
+        assert d.allowed is False
+
+        # Reload with higher limit — limiter should be fresh
+        engine.reload_policy({
+            "name": "test-policy",
+            "version": "1.0",
+            "static_rules": {
+                "rate_limits": {
+                    "default": {"max_calls": 100, "window_seconds": 60},
+                },
+            },
+        })
+        d = engine.evaluate_tool_call("tool", {})
+        assert d.allowed is True

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -135,8 +135,59 @@ class TestReset:
 class TestFromConfig:
     """Build limiter from policy config dict."""
 
+    def test_from_config_without_enabled_is_disabled(self):
+        limiter = ToolRateLimiter.from_config({
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        allowed_first, _ = limiter.check("write_file", now=100.0)
+        allowed_second, _ = limiter.check("write_file", now=100.0)
+        assert allowed_first is True
+        assert allowed_second is True
+
+    def test_from_config_enabled_zero_disables_limiter(self):
+        limiter = ToolRateLimiter.from_config({
+            "enabled": 0,
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        allowed_first, _ = limiter.check("write_file", now=100.0)
+        allowed_second, reason = limiter.check("write_file", now=100.0)
+        assert allowed_first is True
+        assert allowed_second is True
+        assert "disabled" in reason
+
+    def test_from_config_enabled_false_disables_limiter(self):
+        limiter = ToolRateLimiter.from_config({
+            "enabled": False,
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        allowed_first, _ = limiter.check("write_file", now=100.0)
+        allowed_second, _ = limiter.check("write_file", now=100.0)
+        assert allowed_first is True
+        assert allowed_second is True
+
+    def test_from_config_enabled_one_enables_limiter(self):
+        limiter = ToolRateLimiter.from_config({
+            "enabled": 1,
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        allowed_first, _ = limiter.check("write_file", now=100.0)
+        allowed_second, _ = limiter.check("write_file", now=100.0)
+        assert allowed_first is True
+        assert allowed_second is False
+
+    def test_from_config_enabled_true_enables_limiter(self):
+        limiter = ToolRateLimiter.from_config({
+            "enabled": True,
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        allowed_first, _ = limiter.check("write_file", now=100.0)
+        allowed_second, _ = limiter.check("write_file", now=100.0)
+        assert allowed_first is True
+        assert allowed_second is False
+
     def test_from_config(self):
         config = {
+            "enabled": 1,
             "default": {"max_calls": 60, "window_seconds": 60},
             "by_tool": {
                 "write_file": {"max_calls": 10, "window_seconds": 60},
@@ -194,6 +245,7 @@ class TestEngineRateLimitIntegration:
 
     def test_engine_blocks_after_limit(self):
         engine = self._make_engine({
+            "enabled": 1,
             "default": {"max_calls": 2, "window_seconds": 60},
         })
         d1 = engine.evaluate_tool_call("read_file", {})
@@ -206,6 +258,19 @@ class TestEngineRateLimitIntegration:
         assert d3.code == "BLOCK_RATE_LIMIT"
         assert d3.severity == "medium"
 
+    def test_engine_rate_limits_enabled_zero_bypasses_check(self):
+        engine = self._make_engine({
+            "enabled": 0,
+            "default": {"max_calls": 1, "window_seconds": 60},
+        })
+        d1 = engine.evaluate_tool_call("read_file", {})
+        d2 = engine.evaluate_tool_call("read_file", {})
+        d3 = engine.evaluate_tool_call("read_file", {})
+        assert d1.allowed is True
+        assert d2.allowed is True
+        assert d3.allowed is True
+        assert d3.code != "BLOCK_RATE_LIMIT"
+
     def test_engine_no_rate_limits_configured(self):
         engine = IntentGuardEngine(policy={"static_rules": {}})
         decision = engine.evaluate_tool_call("any_tool", {})
@@ -213,6 +278,7 @@ class TestEngineRateLimitIntegration:
 
     def test_engine_reload_policy_rebuilds_limiter(self):
         engine = self._make_engine({
+            "enabled": 1,
             "default": {"max_calls": 1, "window_seconds": 60},
         })
         engine.evaluate_tool_call("tool", {})
@@ -225,6 +291,7 @@ class TestEngineRateLimitIntegration:
             "version": "1.0",
             "static_rules": {
                 "rate_limits": {
+                    "enabled": 1,
                     "default": {"max_calls": 100, "window_seconds": 60},
                 },
             },


### PR DESCRIPTION
## Summary
- Adds `ToolRateLimiter` class in `intent_guard/sdk/rate_limiter.py` with thread-safe, deque-based sliding window rate limiting keyed by tool name
- Integrates rate limit checks into `IntentGuardEngine._run_static_checks()` (fires after token limits, before path checks) with `BLOCK_RATE_LIMIT` decision code
- Supports per-tool overrides and a global default via `static_rules.rate_limits` policy config
- Includes 14 tests covering default limits, per-tool overrides, sliding window expiry, reset, thread safety, and full engine integration

Addresses Resource Exhaustion / DoS vulnerability (arxiv:2601.17549, §6).

## Test plan
- [x] `python -m pytest tests/test_rate_limiting.py -v` — all 14 tests pass
- [ ] Verify rate limiting blocks rapid tool calls in an end-to-end proxy scenario
- [ ] Confirm policy reload resets rate limiter state

🤖 Generated with [Claude Code](https://claude.com/claude-code)