### PR TITLE
Add sensitive argument redaction in decision logs

### DIFF
--- a/intent_guard/sdk/log_redactor.py
+++ b/intent_guard/sdk/log_redactor.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+
+class LogRedactor:
+    """Redacts sensitive values from log dicts based on configured patterns.
+
+    Thread-safe: all state is set during __init__ and never mutated afterwards.
+    """
+
+    def __init__(self, sensitive_data_patterns: list[dict[str, str]]) -> None:
+        self._compiled: list[tuple[str, re.Pattern[str]]] = []
+        for item in sensitive_data_patterns:
+            name = item.get("name", "unknown")
+            pattern = item.get("pattern", "")
+            if pattern:
+                try:
+                    self._compiled.append((name, re.compile(pattern, re.IGNORECASE)))
+                except re.error:
+                    continue
+
+    def redact(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Return a deep copy of *data* with sensitive string values replaced."""
+        cloned = copy.deepcopy(data)
+        return self._walk(cloned)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _walk(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: self._walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._walk(item) for item in value]
+        if isinstance(value, str):
+            return self._redact_string(value)
+        return value
+
+    def _redact_string(self, value: str) -> str:
+        for name, pattern in self._compiled:
+            if pattern.search(value):
+                value = pattern.sub(f"[REDACTED:{name}]", value)
+        return value

--- a/intent_guard/sdk/mcp_proxy.py
+++ b/intent_guard/sdk/mcp_proxy.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 import requests
 
 from intent_guard.sdk.engine import GuardDecision, IntentGuardEngine
+from intent_guard.sdk.log_redactor import LogRedactor
 from intent_guard.sdk.response_guard import ResponseGuard
 from intent_guard.sdk.tool_snapshot import ToolSnapshotStore
 
@@ -106,12 +107,23 @@ class MCPProxy:
         self.logger = logger
         self.advisory_mode = advisory_mode
         self.response_guard = ResponseGuard(self.engine.policy.get("response_rules", {}))
+        self.log_redactor = self._build_log_redactor()
         self.detect_tool_changes = bool(self.engine.policy.get("tool_change_rules", {}).get("enabled", False))
         self.tool_change_action = str(self.engine.policy.get("tool_change_rules", {}).get("action", "warn")).lower()
         if self.tool_change_action not in {"warn", "block"}:
             self.tool_change_action = "warn"
         self.server_id = " ".join(self.target_command) if self.target_command else "default-server"
         self.tool_snapshot_store = ToolSnapshotStore()
+
+    def _build_log_redactor(self) -> LogRedactor | None:
+        static_rules = self.engine.policy.get("static_rules", {})
+        patterns = static_rules.get("sensitive_data_patterns", [])
+        if not patterns:
+            return None
+        redact_logs = static_rules.get("redact_logs", True)
+        if not redact_logs:
+            return None
+        return LogRedactor(patterns)
 
     def process_client_message(self, message: dict[str, Any]) -> tuple[bool, dict[str, Any] | None]:
         if message.get("method") != "tools/call":
@@ -206,6 +218,8 @@ class MCPProxy:
             "semantic_prompt_version": decision.semantic_prompt_version,
             "would_block": not decision.allowed,
         }
+        if self.log_redactor is not None:
+            entry = self.log_redactor.redact(entry)
         if self.logger is not None:
             self.logger(entry)
         else:

--- a/schema/policy.yaml
+++ b/schema/policy.yaml
@@ -31,6 +31,7 @@ static_rules:
       pattern: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"
     - name: "SSN"
       pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b"
+  redact_logs: true
 
 semantic_rules:
   provider: ollama

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from intent_guard.sdk.log_redactor import LogRedactor
+from intent_guard.sdk.engine import IntentGuardEngine
+from intent_guard.sdk.mcp_proxy import MCPProxy
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SENSITIVE_PATTERNS = [
+    {"name": "GitHub Token", "pattern": "gh[ps]_[A-Za-z0-9_]{36,}"},
+    {"name": "AWS Access Key", "pattern": "AKIA[0-9A-Z]{16}"},
+]
+
+FAKE_GH_TOKEN = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmn"
+FAKE_AWS_KEY = "AKIAIOSFODNN7EXAMPLE"
+
+
+@pytest.fixture
+def redactor() -> LogRedactor:
+    return LogRedactor(SENSITIVE_PATTERNS)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – LogRedactor
+# ---------------------------------------------------------------------------
+
+
+class TestLogRedactorBasic:
+    def test_github_token_redacted(self, redactor: LogRedactor) -> None:
+        data = {"arguments": {"token": FAKE_GH_TOKEN}}
+        result = redactor.redact(data)
+        assert FAKE_GH_TOKEN not in str(result)
+        assert "[REDACTED:GitHub Token]" in result["arguments"]["token"]
+
+    def test_aws_key_redacted(self, redactor: LogRedactor) -> None:
+        data = {"key": FAKE_AWS_KEY}
+        result = redactor.redact(data)
+        assert FAKE_AWS_KEY not in str(result)
+        assert "[REDACTED:AWS Access Key]" in result["key"]
+
+    def test_nested_dict_redacted(self, redactor: LogRedactor) -> None:
+        data = {
+            "outer": {
+                "inner": {
+                    "secret": f"prefix {FAKE_GH_TOKEN} suffix",
+                }
+            }
+        }
+        result = redactor.redact(data)
+        assert FAKE_GH_TOKEN not in str(result)
+        assert "[REDACTED:GitHub Token]" in result["outer"]["inner"]["secret"]
+
+    def test_list_values_redacted(self, redactor: LogRedactor) -> None:
+        data = {"tokens": [FAKE_GH_TOKEN, "safe-value", FAKE_AWS_KEY]}
+        result = redactor.redact(data)
+        assert FAKE_GH_TOKEN not in str(result)
+        assert FAKE_AWS_KEY not in str(result)
+        assert result["tokens"][1] == "safe-value"
+
+    def test_non_matching_values_preserved(self, redactor: LogRedactor) -> None:
+        data = {
+            "tool": "read_file",
+            "path": "/tmp/hello.txt",
+            "count": 42,
+            "flag": True,
+            "empty": None,
+        }
+        result = redactor.redact(data)
+        assert result == data
+
+    def test_original_dict_not_mutated(self, redactor: LogRedactor) -> None:
+        data = {"arguments": {"token": FAKE_GH_TOKEN}}
+        original = copy.deepcopy(data)
+        redactor.redact(data)
+        assert data == original
+
+    def test_empty_patterns_passthrough(self) -> None:
+        redactor = LogRedactor([])
+        data = {"token": FAKE_GH_TOKEN}
+        assert redactor.redact(data) == data
+
+    def test_invalid_pattern_skipped(self) -> None:
+        patterns = [
+            {"name": "Bad", "pattern": "[invalid"},
+            {"name": "GitHub Token", "pattern": "gh[ps]_[A-Za-z0-9_]{36,}"},
+        ]
+        redactor = LogRedactor(patterns)
+        data = {"token": FAKE_GH_TOKEN}
+        result = redactor.redact(data)
+        assert "[REDACTED:GitHub Token]" in result["token"]
+
+
+# ---------------------------------------------------------------------------
+# Integration test – MCPProxy logger receives redacted entries
+# ---------------------------------------------------------------------------
+
+
+class TestMCPProxyLogRedaction:
+    def _build_proxy(self, logger: Any, redact_logs: bool = True) -> MCPProxy:
+        policy = {
+            "name": "test-policy",
+            "version": "1.0",
+            "static_rules": {
+                "sensitive_data_patterns": SENSITIVE_PATTERNS,
+                "redact_logs": redact_logs,
+            },
+        }
+        engine = IntentGuardEngine(policy=policy, provider=None)
+        return MCPProxy(
+            engine=engine,
+            target_command=["echo"],
+            logger=logger,
+        )
+
+    def test_logged_entry_has_redacted_args(self) -> None:
+        logged: list[dict[str, Any]] = []
+        proxy = self._build_proxy(logger=logged.append)
+
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "run_command",
+                "arguments": {"cmd": f"curl -H 'Authorization: {FAKE_GH_TOKEN}'"},
+            },
+        }
+        proxy.process_client_message(message)
+
+        assert len(logged) == 1
+        entry = logged[0]
+        assert FAKE_GH_TOKEN not in str(entry)
+        assert "[REDACTED:GitHub Token]" in str(entry)
+
+    def test_redact_logs_false_preserves_raw(self) -> None:
+        logged: list[dict[str, Any]] = []
+        proxy = self._build_proxy(logger=logged.append, redact_logs=False)
+
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "run_command",
+                "arguments": {"cmd": f"curl -H 'Authorization: {FAKE_GH_TOKEN}'"},
+            },
+        }
+        proxy.process_client_message(message)
+
+        assert len(logged) == 1
+        assert FAKE_GH_TOKEN in str(logged[0])
+
+    def test_decision_object_not_mutated(self) -> None:
+        """The actual decision used for enforcement must keep raw arguments."""
+        logged: list[dict[str, Any]] = []
+        proxy = self._build_proxy(logger=logged.append)
+
+        arguments = {"cmd": f"curl -H 'Authorization: {FAKE_GH_TOKEN}'"}
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "run_command", "arguments": arguments},
+        }
+        proxy.process_client_message(message)
+
+        # The original arguments dict passed into the message must be untouched
+        assert FAKE_GH_TOKEN in arguments["cmd"]


### PR DESCRIPTION
## Summary
- Introduces `LogRedactor` class that deep-copies decision dicts and replaces string values matching `sensitive_data_patterns` with `[REDACTED:<pattern-name>]` before they reach the logger callback
- Integrates redaction into `MCPProxy._log_tool_call()` so secrets in tool arguments never appear in plaintext logs, while the actual decision objects used for enforcement remain untouched
- Adds `redact_logs` policy flag under `static_rules` (defaults to `true` when `sensitive_data_patterns` exist)

Addresses Token/Credential Theft vulnerability (arxiv:2601.17549, §3-4) — a compromised log sink could previously expose the very credentials IntentGuard is meant to protect.

## Test plan
- [x] Unit tests for `LogRedactor`: GitHub token redaction, AWS key redaction, nested dict/list handling, non-matching value preservation, deep-copy immutability, empty/invalid pattern handling
- [x] Integration tests for `MCPProxy`: logged entry contains redacted args, `redact_logs: false` preserves raw values, original decision object is not mutated
- [x] All 11 tests in `tests/test_log_redaction.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)